### PR TITLE
Add GitHub Actions labeler for pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,20 @@
+frontend:
+  - changed_files:
+      - any-glob-to-any-file: ["frontend-cal/**"]
+
+backend:
+  - changed_files:
+      - any-glob-to-any-file: ["backend-cal/**"]
+
+devops:
+  - changed_files:
+      - any-glob-to-any-file:
+        - ".github/**"
+        - "**/.devcontainer/**"
+        - "dev/**"
+
+docs:
+  - changed_files:
+      - any-glob-to-any-file:
+        - "**/README.md"
+        - "**/docs/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -22,9 +22,8 @@ jobs:
             github.rest.issues.addLabels({
               owner, repo,
               issue_number: context.payload.pull_request.number,
-              labels: ['${{ inputs.revert_label }}'],
+              labels: ['revert'],
             });
-
 
     permissions:
       actions: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,31 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    name: Add PR labels
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true
+    
+      - name: Add 'revert' label to relevant PRs
+        if: contains(github.event.pull_request.title, 'Revert')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            github.rest.issues.addLabels({
+              owner, repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['${{ inputs.revert_label }}'],
+            });
+
+
+    permissions:
+      actions: write
+      pull-requests: write


### PR DESCRIPTION
Introduce a GitHub Actions configuration to automatically label pull requests based on file changes and add a 'revert' label for relevant PRs.