### PR TITLE
Update backend Dockerfile to use Python 3.12

### DIFF
--- a/dev/Dockerfile-backend
+++ b/dev/Dockerfile-backend
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.12
 
 WORKDIR /app
 


### PR DESCRIPTION
Upgrade the Python version in the backend Dockerfile to 3.12