### PR TITLE
Removed hard coded api key. Used the dotenv package instead

### DIFF
--- a/backend/ai_engine/.gitignore
+++ b/backend/ai_engine/.gitignore
@@ -1,2 +1,7 @@
 # Ignore virtual environment folder
 venv/
+# Environment variables
+app/.env
+# Installed python packages
+app/__pycache__/
+

--- a/backend/ai_engine/app/models.py
+++ b/backend/ai_engine/app/models.py
@@ -16,13 +16,17 @@ from pytubefix import Playlist
 from pytubefix.cli import on_progress
 from typing import List, Dict
 import ffmpeg
-
+from dotenv import load_dotenv
 app = FastAPI()
 os.environ["PATH"] += os.pathsep # + "C:\\ffmpeg\\bin"
 
+load_dotenv()
+
+API_KEY = os.getenv("API_KEY")
+
 def generate_from_gemini(prompt: str, user_api_key: str) -> str:
     model = genai.GenerativeModel(model_name="gemini-2.0-flash-exp")
-    genai.configure(api_key="AIzaSyB5AF8R-5q6nj5CS2wYbHDtRrdGhYOPh-Y")
+    genai.configure(api_key=API_KEY)
     response = model.generate_content(prompt)
     time.sleep(10)  # Delay to prevent hitting API rate limits
     return response.text

--- a/backend/ai_engine/app/templates/index.html
+++ b/backend/ai_engine/app/templates/index.html
@@ -814,7 +814,7 @@ async function processBatches(batches) {
         const payload = {
           url: videoURL,
           user_api_key: document.getElementById('user-api-key').value,
-          timestamps,
+          timestamps: timestamps,
           segment_wise_q_no: segmentWiseQNo,
           segment_wise_q_model: segmentWiseQModel,
         };


### PR DESCRIPTION
Changes the backend/ai_engine to use api key from the environment rather than a hard coded one. We will require the user to provide their own api key in the future. 